### PR TITLE
2018 spring

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,15 +170,11 @@
                         you have collaborated with in your README.</p>
                     </li>
                     <li>
-                        <h5>I want to collaborate.  How?</h5>
-                        <p>Additionally, if you wish to set up a Github
-                        repo for yourself and your partner, the repo must
-                        be private. GitHub offers
-                        <strong><a href="http://www.github.com/edu">free</a> private
-                        repositories (and a bunch of other goodies!) to students,
-                        but it takes a week or two</strong> to
-                        process, so make sure to sign up before the
-                        hackathon.</p>
+                        <h5>What am I going to eat?</h5>
+                        <p>Luckily, we will be situated just one floor above JJ's
+						dining hall! They will be catering some of our favorite late
+						night snacks. Expect sandwiches, fries, chicken wings, fruit, 
+						salad, veggies, and at midnight, a sweet surprise!</p>
                     </li>
                     <li>
                         <h5>Got anything <em>else</em> for me?</h5>
@@ -212,9 +208,9 @@
          <div class="large-12 columns">
            <h2>A storied tradition</h2>
            <h4>
-			   At our <a href="2017_fall.html">Fall 2017 Hackathon</a>, around 300 APers go back to John Jay to hack away at their homework and free food. We were joined by  
+			   At our <a href="2017_fall.html">Fall 2017 Hackathon</a>, around 300 APers went back to John Jay to hack away at their homework and free food. We were joined by  
              <a href="img/2017_fall_photos/large-26.jpg">Stressbusters </a>
-to help ease any tension, and our hackers were suprised at midnight with
+to help ease any tension, and our hackers were surprised at midnight with
 <a href="img/2017_fall_photos/large-106.jpg"> ice cream and cookies</a>! Check out more photos
 
              <a href="2017_fall_photos.html"> here. </a>

--- a/index.html
+++ b/index.html
@@ -221,10 +221,32 @@
         </div>
     </section>
 
+
+	<section id="last-year">
+       	<div class="row">
+         <div class="large-12 columns">
+           <h2>A storied tradition</h2>
+           <h4>
+             At our Fall 2017 Hackathon, around 300 APers go back to John Jay to hack away at their homework and free food. We were joined by  
+             <a href="img/2017_fall_photos/large-26.jpg">Stressbusters </a>
+to help ease any tension, and our hackers were suprised at midnight with
+<a href="2017_fall_photos/large-106.jpg"> ice cream and cookie </a>! Check out more photos
+
+             <a href="2017_fall_photos.html"> here. </a>
+           </h4>
+         </div>
+       </div>
+     </section>
+     <ul class="small-block-grid-3 image-list">
+       <li><a href="img/2017_spring_photos/large-19.jpg"><img src="img/2017_spring_photos/large-19.jpg"></a></li>
+       <li><a href="img/2017_spring_photos/large-33.jpg"><img src="img/2017_spring_photos/large-33.jpg"></a></li>
+       <li><a href="img/2017_spring_photos/large-41.jpg"><img src="img/2017_spring_photos/large-41.jpg"></a></li>
+     </ul>
+
     <section id="history">
       <div class="row">
         <div class="large-12 columns">
-          <h2>A storied tradition</h2>
+          <h2>Every year we get bigger and better</h2>
           <h4>
             At our <a href="2017_spring.html">Spring 2017 Hackathon</a>, we had 220+ Hackers join us in Lerner Party Space to work on Lab 4. Swag,
             food and company made this hackathon as successful as any. Upping the ante, our midnight surprise
@@ -250,7 +272,6 @@
         <div class="row">
 
             <div class="large-12 columns">
-                <h2>Every year we get bigger and better</h2>
                 <h4>At our <a href="2016_fall.html">Fall 2016 Hackathon</a>  over 300 hackers joined us
 									in Roone Arledge Auditorium to work on Lab 3, collect swag, eat food, and witness the unveiling of the
 									midnight surprise&mdash;Insomnia cookies! Check out some <a

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 <div class="large-12 columns">
                     <div class="hero-content">
                         <h1>3157 Hackathon</h1>
-                        <h2>Join us for our 10th Semester-versary on  March 2nd!</h2>
+                        <h2>Join us for our 1010th anniversary on  March 2nd!</h2>
                       	<h2> 
                         	Check out photos <a href="2017_fall_photos.html"> here! </a>
                       	</h2> 

--- a/index.html
+++ b/index.html
@@ -30,9 +30,7 @@
             <ul class="right">
               <li><a>March 2nd, 7:30pm-2am, John Jay Dining Hall</a></li>
               <!-- link to RSVP survey -->
-							<!--
-              <li class="active"><a href="https://docs.google.com/forms/d/e/1FAIpQLSejESjn-r3lXNNsmD5LTmJcCejlbiNvnNakXExAQJtkodtd0A/viewform?usp=sf_link" target="_blank">RSVP</a></li>
-							-->
+              <li class="active"><a href="https://docs.google.com/forms/d/1lFYdtKPMb3UuVmta4UPZtJ5kqwtl6Q4uHJQK8nbzisk/edit"_blank">RSVP</a></li>
             </ul>
             <ul class="left">
               <li><a href="#about">About</a></li>
@@ -73,13 +71,7 @@
 							</a>
 						</div>
         </div>
-	</section> --!>
-    <ul class="small-block-grid-3 image-list">
-      <li><a href="img/2017_fall_photos/large-31.jpg"><img src="img/2017_fall_photos/large-31.jpg"></a></li>
-      <li><a href="img/2017_fall_photos/large-10.jpg"><img src="img/2017_fall_photos/large-10.jpg"></a></li>
-      <li><a href="img/2017_fall_photos/large-46.jpg"><img src="img/2017_fall_photos/large-46.jpg"></a></li>
-    </ul>
-		<!-- -->
+  	<!-- -->
     <section id="about">
         <div class="row">
             <div class="large-12 columns">
@@ -121,9 +113,7 @@
                 <p>
                     ​There is no demo, there is no judging, and there is no prize.  Just a night of hacking, good food, laughter, and friendship. Feel good about asking for help and helping others.  No showing off and no embarrassment. We are very proud that for Columbia CS students new to hackathons, their first experience is one of cooperation and friendship, not of competition.
                 </p>
-								<!--
-                <a href="https://docs.google.com/forms/d/e/1FAIpQLSejESjn-r3lXNNsmD5LTmJcCejlbiNvnNakXExAQJtkodtd0A/viewform?usp=sf_link" class="button">RSVP Now!</a>
-								-->
+                <a href="https://docs.google.com/forms/d/1lFYdtKPMb3UuVmta4UPZtJ5kqwtl6Q4uHJQK8nbzisk/edit" class="button">RSVP Now!</a>
             </div>
             <div class="medium-6 columns">
                 <img src="img/peace.jpg">
@@ -213,9 +203,7 @@
             <div class="large-12 columns">
                 <h2>Ok, <strong>I'm in.</strong></h2>
                 <h4>Glad to hear it.  
-									<!--
-                  <a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSejESjn-r3lXNNsmD5LTmJcCejlbiNvnNakXExAQJtkodtd0A/viewform?usp=sf_link">RSVP here</a>. 
-									-->
+                  <a target="_blank" href="https://docs.google.com/forms/d/1lFYdtKPMb3UuVmta4UPZtJ5kqwtl6Q4uHJQK8nbzisk/edit">RSVP here</a>. 
                   We'll see you there!</h4>
             </div>
         </div>
@@ -227,21 +215,21 @@
          <div class="large-12 columns">
            <h2>A storied tradition</h2>
            <h4>
-             At our Fall 2017 Hackathon, around 300 APers go back to John Jay to hack away at their homework and free food. We were joined by  
+			   At our <a href="2017_fall.html">Fall 2017 Hackathon</a>, around 300 APers go back to John Jay to hack away at their homework and free food. We were joined by  
              <a href="img/2017_fall_photos/large-26.jpg">Stressbusters </a>
 to help ease any tension, and our hackers were suprised at midnight with
-<a href="2017_fall_photos/large-106.jpg"> ice cream and cookies </a>! Check out more photos
+<a href="img/2017_fall_photos/large-106.jpg"> ice cream and cookies</a>! Check out more photos
 
              <a href="2017_fall_photos.html"> here. </a>
            </h4>
          </div>
        </div>
-     </section>
-     <ul class="small-block-grid-3 image-list">
-       <li><a href="img/2017_spring_photos/large-19.jpg"><img src="img/2017_spring_photos/large-19.jpg"></a></li>
-       <li><a href="img/2017_spring_photos/large-33.jpg"><img src="img/2017_spring_photos/large-33.jpg"></a></li>
-       <li><a href="img/2017_spring_photos/large-41.jpg"><img src="img/2017_spring_photos/large-41.jpg"></a></li>
-     </ul>
+      </section>
+    <ul class="small-block-grid-3 image-list">
+      <li><a href="img/2017_fall_photos/large-31.jpg"><img src="img/2017_fall_photos/large-31.jpg"></a></li>
+      <li><a href="img/2017_fall_photos/large-10.jpg"><img src="img/2017_fall_photos/large-10.jpg"></a></li>
+      <li><a href="img/2017_fall_photos/large-46.jpg"><img src="img/2017_fall_photos/large-46.jpg"></a></li>
+    </ul>
 
     <section id="history">
       <div class="row">

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 <div class="large-12 columns">
                     <div class="hero-content">
                         <h1>3157 Hackathon</h1>
-                        <h2>Join us for another great hackathon on March 2nd!</h2>
+                        <h2>Join us for our 10th Semester-versary on  March 2nd!</h2>
                       	<h2> 
                         	Check out photos <a href="2017_fall_photos.html"> here! </a>
                       	</h2> 
@@ -230,7 +230,7 @@
              At our Fall 2017 Hackathon, around 300 APers go back to John Jay to hack away at their homework and free food. We were joined by  
              <a href="img/2017_fall_photos/large-26.jpg">Stressbusters </a>
 to help ease any tension, and our hackers were suprised at midnight with
-<a href="2017_fall_photos/large-106.jpg"> ice cream and cookie </a>! Check out more photos
+<a href="2017_fall_photos/large-106.jpg"> ice cream and cookies </a>! Check out more photos
 
              <a href="2017_fall_photos.html"> here. </a>
            </h4>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 
           <section class="top-bar-section">
             <ul class="right">
-              <li><a>October 20th, 7:30pm-2am, John Jay Dining Hall</a></li>
+              <li><a>March 2nd, 7:30pm-2am, John Jay Dining Hall</a></li>
               <!-- link to RSVP survey -->
 							<!--
               <li class="active"><a href="https://docs.google.com/forms/d/e/1FAIpQLSejESjn-r3lXNNsmD5LTmJcCejlbiNvnNakXExAQJtkodtd0A/viewform?usp=sf_link" target="_blank">RSVP</a></li>
@@ -49,18 +49,16 @@
                 <div class="large-12 columns">
                     <div class="hero-content">
                         <h1>3157 Hackathon</h1>
-											<!--
-                        <h2>Join us for another great hackathon on October 20th!</h2>
-                      <h2> 
-                        Check out photos <a href="2017_fall_photos.html"> here! </a>
-                      </h2> 
-											-->
+                        <h2>Join us for another great hackathon on March 2nd!</h2>
+                      	<h2> 
+                        	Check out photos <a href="2017_fall_photos.html"> here! </a>
+                      	</h2> 
                     </div>
                 </div>
             </div>
         </div>
     </div>
-		<!-- -->
+		<!--
     <section class="gray">
         <div class="row">
             <div class="large-12 columns">
@@ -75,7 +73,7 @@
 							</a>
 						</div>
         </div>
-    </section>
+	</section> --!>
     <ul class="small-block-grid-3 image-list">
       <li><a href="img/2017_fall_photos/large-31.jpg"><img src="img/2017_fall_photos/large-31.jpg"></a></li>
       <li><a href="img/2017_fall_photos/large-10.jpg"><img src="img/2017_fall_photos/large-10.jpg"></a></li>
@@ -117,7 +115,7 @@
         <div class="row">
             <div class="medium-6 columns">
                 <p>
-                    Hackathon! On Friday, October 20th, from 7:30pm to 2am students will be working in John Jay dining
+                    Hackathon! On Friday, March 2nd, from 7:30pm to 2am students will be working in John Jay dining
                     hall on a major assignment: <code>lab4</code>. Alumni and TAs will be around to help, too.
                 </p>
                 <p>

--- a/index.html
+++ b/index.html
@@ -48,9 +48,6 @@
                     <div class="hero-content">
                         <h1>3157 Hackathon</h1>
                         <h2>Join us for our 1010th anniversary on  March 2nd!</h2>
-                      	<h2> 
-                        	Check out photos <a href="2017_fall_photos.html"> here! </a>
-                      	</h2> 
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Updated website for 2018 Spring. Reopened RSVP links, shifted the images to accommodate most recent hackathon, and addressed typos.